### PR TITLE
Emails not honoring subject line

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -1243,14 +1243,8 @@ implements TemplateVariable {
                 //Lookup the user using the email address
                 && ($user = User::lookup(array('emails__address' => $mailinfo['email'])))) {
             //We have a valid ticket and user
-            if ($ticket->getUserId() == $user->getId() //owner
-                    ||  ($c = Collaborator::lookup( // check if collaborator
-                            array('user_id' => $user->getId(),
-                                  'thread_id' => $ticket->getThreadId())))) {
-
-                $mailinfo['userId'] = $user->getId();
-                return $ticket->getLastMessage();
-            }
+					
+           return $ticket->getLastMessage();
         }
 
         return null;


### PR DESCRIPTION
This removes the requirement of the emailer to be a collaborator, or the owner, all responses with the ticket number in the subject should got to the ticket.
